### PR TITLE
add custom directory name parameter to clone command

### DIFF
--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -18,7 +18,7 @@ public final class Git: Shell {
         case status(short: Bool = false)
         case commit(message: String, Bool = false)
         case config(name: String, value: String)
-        case clone(url: String)
+        case clone(url: String , dirName: String? = nil)
         case checkout(branch: String, create: Bool = false)
         case log(numberOfCommits: Int? = nil, options: [String]? = nil, revisions: String? = nil)
         case push(remote: String? = nil, branch: String? = nil)
@@ -57,8 +57,11 @@ public final class Git: Shell {
                 if allowEmpty {
                     params.append("--allow-empty")
                 }
-            case .clone(let url):
+            case .clone(let url, let dirname):
                 params = [Command.clone.rawValue, url]
+                if let dirName = dirname {
+                    params.append(dirName)
+                }
             case .checkout(let branch, let create):
                 params = [Command.checkout.rawValue]
                 if create {

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -103,6 +103,25 @@ final class GitKitTests: XCTestCase {
         try self.clean(path: path)
         self.assert(type: "output", result: statusOutput, expected: expectation)
     }
+    
+    func testCloneWithDirectory() throws {
+        let path = self.currentPath()
+        
+        let expectation = """
+            On branch master
+            Your branch is up to date with 'origin/master'.
+
+            nothing to commit, working tree clean
+            """
+
+        try self.clean(path: path)
+        let git = Git(path: path)
+        
+        try git.run(.clone(url: "git@github.com:binarybirds/shell-kit", dirName: "MyCustomDirectory"))
+        let statusOutput = try git.run("cd \(path)/MyCustomDirectory && git status")
+        try self.clean(path: path)
+        self.assert(type: "output", result: statusOutput, expected: expectation)
+    }
 
     #if os(macOS)
     func testAsyncRun() throws {


### PR DESCRIPTION
I added a test case, but even on the `main` branch, all but `testInit` are failing, I haven't looked closely at why.