### PR TITLE
add submodule foreach

### DIFF
--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -29,6 +29,7 @@ public final class Git: Shell {
         case tag(String)
         case fetch(remote: String? = nil, branch: String? = nil)
         case submoduleUpdate(init: Bool = false, recursive: Bool = false, rebase: Bool = false)
+        case submoduleForeach(recursive: Bool = false, command: String)
         case renameRemote(oldName: String, newName: String)
         case addRemote(name: String, url: String)
         case revParse(abbrevRef: String)
@@ -117,6 +118,12 @@ public final class Git: Shell {
                 if rebase {
                     params.append("--rebase")
                 }
+            case .submoduleForeach(let recursive, let command):
+                params = [Command.submodule.rawValue, "foreach"]
+                if recursive {
+                    params.append("--recursive")
+                }
+                params.append(command)
             case .renameRemote(let oldName, let newName):
                 params = [Command.remote.rawValue, "rename", oldName, newName]
             case .addRemote(let name, let url):


### PR DESCRIPTION
i need to be able to iterate through submodules.

the way this API is growing, with `submoduleUpdate` etc, makes me think that long term it'd probably be better to have a sub-enum for `submodule` aliases, which then has a case for each submodule command:
```
       git submodule [--quiet] [--cached]
       git submodule [--quiet] add [<options>] [--] <repository> [<path>]
       git submodule [--quiet] status [--cached] [--recursive] [--] [<path>...]
       git submodule [--quiet] init [--] [<path>...]
       git submodule [--quiet] deinit [-f|--force] (--all|[--] <path>...)
       git submodule [--quiet] update [<options>] [--] [<path>...]
       git submodule [--quiet] set-branch [<options>] [--] <path>
       git submodule [--quiet] set-url [--] <path> <newurl>
       git submodule [--quiet] summary [<options>] [--] [<path>...]
       git submodule [--quiet] foreach [--recursive] <command>
       git submodule [--quiet] sync [--recursive] [--] [<path>...]
       git submodule [--quiet] absorbgitdirs [--] [<path>...]
       ```