### PR TITLE
feat: add config reading and disambiguate between read/write

### DIFF
--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -17,7 +17,8 @@ public final class Git: Shell {
         case addAll
         case status(short: Bool = false)
         case commit(message: String, Bool = false)
-        case config(name: String, value: String)
+        case writeConfig(name: String, value: String)
+        case readConfig(name: String)
         case clone(url: String)
         case checkout(branch: String, create: Bool = false)
         case log(numberOfCommits: Int? = nil, options: [String]? = nil, revisions: String? = nil)
@@ -135,10 +136,12 @@ public final class Git: Shell {
                 params = [Command.remote.rawValue, "add", name, url]
             case .raw(let command):
                 params.append(command)
-            case .config(name: let name, value: let value):
+            case .writeConfig(let name, let value):
                 params = [Command.config.rawValue, "--add", name, value]
             case .revParse(abbrevRef: let abbrevRef):
                 params = [Command.revParse.rawValue, "--abbrev-ref", abbrevRef]
+            case .readConfig(let name):
+                params = [Command.config.rawValue, "--get", name]
             case .revList(let branch, let count, let revisions):
                 params = [Command.revList.rawValue]
                 if count {


### PR DESCRIPTION
I had a need to _read_ values from git config. any change to this would be breaking (at least any way i could think of to change it to support both use cases), so i figured it might make sense to make parallel read/write paths and make the names more obvious.