### PR TITLE
feat: rev-parse optional abbrev ref

### DIFF
--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -149,6 +149,12 @@ public final class Git: Shell {
                 if let revisions = revisions {
                     params.append(revisions)
                 }
+            case .revParse(let abbrevRef, let revision):
+                params = [Command.revParse.rawValue]
+                if abbrevRef {
+                    params.append("--abbrev-ref")
+                }
+                params.append(revision)
             case .lsRemote(url: let url, limitToHeads: let limitToHeads):
                 params = [Command.lsRemote.rawValue]
                 if limitToHeads {

--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -32,7 +32,11 @@ public final class Git: Shell {
         case submoduleForeach(recursive: Bool = false, command: String)
         case renameRemote(oldName: String, newName: String)
         case addRemote(name: String, url: String)
-        case revParse(abbrevRef: String)
+
+        /// - parameter abbrevRef whether or not the result should be the abbreviated reference name or the full commit SHA hash
+        /// - parameter revision the name of the revision to parse. can be symbolic (`@`), human-readable (`origin/HEAD`) or a commit SHA hash
+        case revParse(abbrevRef: Bool, revision: String)
+
         case revList(branch: String, count: Bool = false, revisions: String? = nil)
         case raw(String)
         case lsRemote(url: String, limitToHeads: Bool = false)
@@ -137,8 +141,6 @@ public final class Git: Shell {
                 params.append(command)
             case .config(name: let name, value: let value):
                 params = [Command.config.rawValue, "--add", name, value]
-            case .revParse(abbrevRef: let abbrevRef):
-                params = [Command.revParse.rawValue, "--abbrev-ref", abbrevRef]
             case .revList(let branch, let count, let revisions):
                 params = [Command.revList.rawValue]
                 if count {

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -113,7 +113,7 @@ final class GitKitTests: XCTestCase {
         
         // Initialize a repository and make an initial commit
         try git.run(.raw("init"))
-        try git.run(.commit(message: "initial commit", true))
+        try git.run(.commit(message: "initial commit", allowEmpty: true))
         
         // Test 1: Get abbreviated reference name for HEAD
         let abbrevRef = try git.run(.revParse(abbrevRef: true, revision: "HEAD"))

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -110,29 +110,23 @@ final class GitKitTests: XCTestCase {
         
         try self.clean(path: path)
         let git = Git(path: path)
-        
-        // Initialize a repository and make an initial commit
+
         try git.run(.raw("init"))
         try git.run(.commit(message: "initial commit", allowEmpty: true))
-        
-        // Test 1: Get abbreviated reference name for HEAD
+
         let abbrevRef = try git.run(.revParse(abbrevRef: true, revision: "HEAD"))
         XCTAssertEqual(abbrevRef, "main", "Should return abbreviated reference name")
 
-        // Test 2: Get full commit SHA for HEAD
         let fullSHA = try git.run(.revParse(abbrevRef: false, revision: "HEAD"))
         XCTAssertTrue(fullSHA.count == 40, "Should return full 40-character SHA")
         XCTAssertTrue(fullSHA.allSatisfy { $0.isHexDigit }, "SHA should contain only hex characters")
-        
-        // Test 3: Parse symbolic reference (@)
+
         let symbolicRef = try git.run(.revParse(abbrevRef: false, revision: "@"))
         XCTAssertEqual(symbolicRef, fullSHA, "Symbolic '@' should resolve to same SHA as HEAD")
-        
-        // Test 4: Get abbreviated reference for current branch
+
         let currentBranch = try git.run(.revParse(abbrevRef: true, revision: "@"))
         XCTAssertEqual(currentBranch, "main", "Should return current branch name")
 
-        // Clean up
         try self.clean(path: path)
     }
 

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -25,6 +25,7 @@ final class GitKitTests: XCTestCase {
         ("testLog", testLog),
         ("testCommandWithArgs", testCommandWithArgs),
         ("testClone", testClone),
+        ("testRevParse", testRevParse),
     ]
     
     // MARK: - helpers
@@ -102,6 +103,37 @@ final class GitKitTests: XCTestCase {
         let statusOutput = try git.run("cd \(path)/shell-kit && git status")
         try self.clean(path: path)
         self.assert(type: "output", result: statusOutput, expected: expectation)
+    }
+
+    func testRevParse() throws {
+        let path = self.currentPath()
+        
+        try self.clean(path: path)
+        let git = Git(path: path)
+        
+        // Initialize a repository and make an initial commit
+        try git.run(.raw("init"))
+        try git.run(.commit(message: "initial commit", true))
+        
+        // Test 1: Get abbreviated reference name for HEAD
+        let abbrevRef = try git.run(.revParse(abbrevRef: true, revision: "HEAD"))
+        XCTAssertEqual(abbrevRef, "main", "Should return abbreviated reference name")
+
+        // Test 2: Get full commit SHA for HEAD
+        let fullSHA = try git.run(.revParse(abbrevRef: false, revision: "HEAD"))
+        XCTAssertTrue(fullSHA.count == 40, "Should return full 40-character SHA")
+        XCTAssertTrue(fullSHA.allSatisfy { $0.isHexDigit }, "SHA should contain only hex characters")
+        
+        // Test 3: Parse symbolic reference (@)
+        let symbolicRef = try git.run(.revParse(abbrevRef: false, revision: "@"))
+        XCTAssertEqual(symbolicRef, fullSHA, "Symbolic '@' should resolve to same SHA as HEAD")
+        
+        // Test 4: Get abbreviated reference for current branch
+        let currentBranch = try git.run(.revParse(abbrevRef: true, revision: "@"))
+        XCTAssertEqual(currentBranch, "main", "Should return current branch name")
+
+        // Clean up
+        try self.clean(path: path)
     }
 
     #if os(macOS)


### PR DESCRIPTION
I have a need to get both the full commit hash for a revision, and separately, the abbreviated reference name

Test run passed at https://github.com/armcknight/git-kit/pull/6