### PR TITLE
feat: add parameter to checkout to specify a remote tracking branch

### DIFF
--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -157,7 +157,7 @@ public final class Git: Shell {
                 params = [Command.config.rawValue, "--add", name, value]
             case .readConfig(let name):
                 params = [Command.config.rawValue, "--get", name]
-            case .revList(let branch, let count, let revisions):
+            case .revList(_, let count, let revisions):
                 params = [Command.revList.rawValue]
                 if count {
                     params.append("--count")

--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -19,7 +19,12 @@ public final class Git: Shell {
         case commit(message: String, Bool = false)
         case config(name: String, value: String)
         case clone(url: String)
-        case checkout(branch: String, create: Bool = false)
+
+        /// - parameter branch the name of the branch to checkout
+        /// - parameter create whether to create a new branch or checkout an existing one
+        /// - parameter tracking when creating a new branch, the name of the remote branch it should track
+        case checkout(branch: String, create: Bool = false, tracking: String? = nil)
+
         case log(numberOfCommits: Int? = nil, options: [String]? = nil, revisions: String? = nil)
         case push(remote: String? = nil, branch: String? = nil)
         case pull(remote: String? = nil, branch: String? = nil, rebase: Bool = false)
@@ -59,12 +64,15 @@ public final class Git: Shell {
                 }
             case .clone(let url):
                 params = [Command.clone.rawValue, url]
-            case .checkout(let branch, let create):
+            case .checkout(let branch, let create, let tracking):
                 params = [Command.checkout.rawValue]
                 if create {
                     params.append("-b")
                 }
                 params.append(branch)
+                if let tracking {
+                    params.append(tracking)
+                }
             case .log(let numberOfCommits, let options, let revisions):
                 params = [Command.log.rawValue]
                 if let numberOfCommits = numberOfCommits {

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -25,6 +25,7 @@ final class GitKitTests: XCTestCase {
         ("testLog", testLog),
         ("testCommandWithArgs", testCommandWithArgs),
         ("testClone", testClone),
+        ("testCheckoutRemoteTracking", testCheckoutRemoteTracking),
     ]
     
     // MARK: - helpers
@@ -102,6 +103,25 @@ final class GitKitTests: XCTestCase {
         let statusOutput = try git.run("cd \(path)/shell-kit && git status")
         try self.clean(path: path)
         self.assert(type: "output", result: statusOutput, expected: expectation)
+    }
+
+    func testCheckoutRemoteTracking() throws {
+        let path = self.currentPath()
+        
+        try self.clean(path: path)
+        let git = Git(path: path)
+
+        try git.run(.clone(url: "https://github.com/binarybirds/shell-kit.git"))
+
+        let repoPath = "\(path)/shell-kit"
+        let repoGit = Git(path: repoPath)
+
+        try repoGit.run(.checkout(branch: "feature-branch", create: true, tracking: "origin/main"))
+        let branchOutput = try repoGit.run(.raw("branch -vv"))
+        try self.clean(path: path)
+
+        XCTAssertTrue(branchOutput.contains("feature-branch"), "New branch should be created")
+        XCTAssertTrue(branchOutput.contains("origin/main"), "Branch should track origin/main")
     }
 
     #if os(macOS)

--- a/Tests/GitKitTests/GitKitTests.swift
+++ b/Tests/GitKitTests/GitKitTests.swift
@@ -107,7 +107,11 @@ final class GitKitTests: XCTestCase {
     }
 
     func testCheckoutRemoteTracking() throws {
-      try git.run(.clone(url: "https://github.com/binarybirds/shell-kit.git"))
+        let path = self.currentPath()
+        try self.clean(path: path)
+        let git = Git(path: path)
+        
+        try git.run(.clone(url: "https://github.com/binarybirds/shell-kit.git"))
 
         let repoPath = "\(path)/shell-kit"
         let repoGit = Git(path: repoPath)
@@ -121,9 +125,7 @@ final class GitKitTests: XCTestCase {
     }
 
     func testRevParse() throws {
-
         let path = self.currentPath()
-        
         try self.clean(path: path)
         let git = Git(path: path)
 


### PR DESCRIPTION
I needed this because I have some automation set up for managing forks locally. The way I like to do this is by having two remotes, `upstream` and `fork`, and i track each one's default branch separately locally in branches named `fork_main` and `upstream_main`, but since those aren't the remote names of those refs, I need to set the tracking branch manually when running `git checkout -b`