### PR TITLE
fix(log): place revisions parameter before end of options

### DIFF
--- a/Sources/GitKit/Git.swift
+++ b/Sources/GitKit/Git.swift
@@ -87,7 +87,6 @@ public final class Git: Shell {
                 if let options = options {
                     params.append(contentsOf: options)
                 }
-                params.append("--")
                 if let revisions = revisions {
                     params.append(revisions)
                 }


### PR DESCRIPTION
Noticed this while working on https://github.com/BinaryBirds/git-kit/pull/18, it caused the git command to fail with usage output.